### PR TITLE
correct index source in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ config :elasticsearch,
       #
       # Each piece of data that is returned by the store must implement the
       # Elasticsearch.Document protocol.
-      sources: [Post]
+      sources: [MyApp.Post]
     }
   }
 ```


### PR DESCRIPTION
all the other examples in the `README` are prefixed with `MyApp.` .. so in case something would be using them as starting point, it wouldn't work out of the box because the store wouldn't be able to load a few records as sample as it should be.